### PR TITLE
Fix protocol specification markup.

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -49,7 +49,7 @@ If `objectIds` includes a `commit`, then all `tree`s recursively referenced by t
 If any other object type is requested (`tree`, `blob`, or `tag`), then only that object will be returned.
 
 `commitDepth` - if the requested object is a `commit`, all parents up to `n` levels deep will be returned, along
-with all their trees as previously described. Does not include any 'blob's.
+with all their trees as previously described. Does not include any `blob`s.
 
 ## `Accept: application/x-gvfs-loose-objects`
 
@@ -100,7 +100,7 @@ To enable the reuse of already-existing packfiles and indexes, a custom format f
 is supported. The `prefetch` endpoint will return one or more packfiles of **non-blob** objects.  
 
 If the optional `lastPackTimestamp` query parameter is supplied, only packs created by the server
-after the specific Unix epoch time (approximately, ±10 minutes or so) will be returned. Generally, these packs 
+after the specific Unix epoch time (approximately, Â±10 minutes or so) will be returned. Generally, these packs 
 will contain only objects introduced to the repository after that UTC-based timestamp, but will not contain
 **all** objects introduced after that timestamp.
 


### PR DESCRIPTION
One of the `blob` was written as 'blob' and thus wasn't rendered as a code element